### PR TITLE
fix: add network security config to block cleartext traffic

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:enableOnBackInvokedCallback="true"
         android:fullBackupContent="@xml/backup_rules"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false" />
+</network-security-config>


### PR DESCRIPTION
## Summary
- Adds `network_security_config.xml` disallowing cleartext HTTP
- References it from `AndroidManifest.xml`

## Detail
With `minSdk=27`, cleartext traffic is permitted by default. All API calls already use HTTPS (`api.getbible.life`), so this makes the implicit guarantee explicit and prevents accidental downgrades.

**Severity:** Medium