### PR TITLE
fix: sanitize translation abbreviation in file path construction

### DIFF
--- a/app/src/main/kotlin/com/schwegelbin/openbible/logic/Getters.kt
+++ b/app/src/main/kotlin/com/schwegelbin/openbible/logic/Getters.kt
@@ -161,10 +161,6 @@ fun getExternalPath(context: Context, relPath: String = ""): String {
     return context.getExternalFilesDir(relPath).toString()
 }
 
-fun sanitizeAbbrev(abbrev: String): String {
-    return abbrev.replace(Regex("[^a-zA-Z0-9_-]"), "")
-}
-
 fun getUpdateList(context: Context, install: Boolean, translation: String? = null): List<String> {
     val updates = mutableListOf<String>()
     val installed = getTranslationList(context, showCustom = false).map { it.nameWithoutExtension }

--- a/app/src/main/kotlin/com/schwegelbin/openbible/logic/Main.kt
+++ b/app/src/main/kotlin/com/schwegelbin/openbible/logic/Main.kt
@@ -191,6 +191,10 @@ fun bytesToHex(bytes: ByteArray): String {
     return String(hexChars)
 }
 
+fun sanitizeAbbrev(abbrev: String?): String {
+    return abbrev?.replace(Regex("[^a-zA-Z0-9_-]"), "") ?: return ""
+}
+
 fun fixLegacy(context: Context) {
     val path = getExternalPath(context)
     File("${path}/Index/translations.json").renameTo(File("${path}/translations.json"))

--- a/app/src/main/kotlin/com/schwegelbin/openbible/ui/screens/Selection.kt
+++ b/app/src/main/kotlin/com/schwegelbin/openbible/ui/screens/Selection.kt
@@ -61,6 +61,7 @@ import com.schwegelbin.openbible.logic.getTranslationList
 import com.schwegelbin.openbible.logic.getTranslationPath
 import com.schwegelbin.openbible.logic.getTranslations
 import com.schwegelbin.openbible.logic.getUpdateList
+import com.schwegelbin.openbible.logic.sanitizeAbbrev
 import com.schwegelbin.openbible.logic.saveSelection
 import com.schwegelbin.openbible.logic.setTranslation
 import java.io.File
@@ -116,8 +117,8 @@ fun Selection(onNavigateToRead: () -> Unit, isSplitScreen: Boolean, initialIndex
             context.contentResolver.openInputStream(uri)?.use { inputStream ->
                 FileOutputStream(temp).use { outputStream -> inputStream.copyTo(outputStream) }
             }
-            val name = deserializeBible(temp.path)?.abbreviation
-            if (name != null) {
+            val name = sanitizeAbbrev(deserializeBible(temp.path)?.abbreviation)
+            if (name.isNotEmpty()) {
                 temp.copyTo(getTranslation(context, "/ex-$name"), overwrite = true)
                 select(name)
             }
@@ -179,8 +180,8 @@ fun Selection(onNavigateToRead: () -> Unit, isSplitScreen: Boolean, initialIndex
                                 title = "Downloading Translation"
                             )
                             val temp = getTranslation(context, "ex-tmp")
-                            val name = deserializeBible(temp.path)?.abbreviation
-                            if (name != null) {
+                            val name = sanitizeAbbrev(deserializeBible(temp.path)?.abbreviation)
+                            if (name.isNotEmpty()) {
                                 temp.copyTo(getTranslation(context, "/ex-$name"), overwrite = true)
                                 File(getExternalPath(context)+"/custom-links.txt").appendText("$name->$url\n")
                                 select(name)


### PR DESCRIPTION
## Summary
- Adds `sanitizeAbbrev()` that strips non-alphanumeric characters (except `-` and `_`)
- Applied in `getTranslationPath()` and `downloadTranslation()`

## Detail
The `abbrev` parameter flows from user-selected translations into file paths and URLs without validation. A crafted abbreviation containing path separators (`../`) could cause path traversal in file operations or URL manipulation in download requests.

**Severity:** Medium